### PR TITLE
Make selecting more generic

### DIFF
--- a/sqlbuilder/dialect/mysql/mysql.go
+++ b/sqlbuilder/dialect/mysql/mysql.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/column"
 	"github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/conflict"
 	"github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/filter"
+	"github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/internal/expr"
 	"github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/internal/params"
 )
 
@@ -16,12 +17,42 @@ func Now() string {
 
 type Dialect struct{}
 
-func (m Dialect) SelectStmt(table string, fields ...string) (string, error) {
-	return `SELECT ` + strings.Join(fields, `,`) + ` FROM ` + table, nil
+func (m Dialect) ResolveExpr(ex expr.Expr) (string, error) {
+	switch te := ex.(type) {
+	case expr.Column:
+		if te.IsQualified() {
+			return te.Database + `.` + te.Name, nil
+		} else {
+			return te.Name, nil
+		}
+	}
+
+	return ``, fmt.Errorf(`unsupported expression type: %T`, ex)
 }
 
-func (m Dialect) SelectForUpdateStmt(table string, fields ...string) (string, error) {
-	return `SELECT ` + strings.Join(fields, `,`) + ` FROM ` + table + ` FOR UPDATE`, nil
+func (m Dialect) SelectStmt(table string, fields ...expr.Expr) (string, error) {
+	return m.selectStmt(table, fields...)
+}
+
+func (m Dialect) SelectForUpdateStmt(table string, fields ...expr.Expr) (string, error) {
+	stmt, err := m.selectStmt(table, fields...)
+	if err != nil {
+		return ``, err
+	}
+	return stmt + ` FOR UPDATE`, nil
+}
+
+func (m Dialect) selectStmt(table string, fields ...expr.Expr) (string, error) {
+	resolved := make([]string, 0, len(fields))
+	for _, f := range fields {
+		r, err := m.ResolveExpr(f)
+		if err != nil {
+			return ``, err
+		}
+
+		resolved = append(resolved, r)
+	}
+	return `SELECT ` + strings.Join(resolved, `,`) + ` FROM ` + table, nil
 }
 
 func (m Dialect) OrderBy(o filter.Order) (string, error) {

--- a/sqlbuilder/dialect/mysql/mysql.go
+++ b/sqlbuilder/dialect/mysql/mysql.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/column"
 	"github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/conflict"
 	"github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/filter"
+	"github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/functions"
 	"github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/internal/expr"
 	"github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/internal/params"
 )
@@ -25,6 +26,18 @@ func (m Dialect) ResolveExpr(ex expr.Expr) (string, error) {
 		} else {
 			return te.Name, nil
 		}
+
+	case functions.Count:
+		if te.All() {
+			return `COUNT(*)`, nil
+		}
+		c := `COUNT(`
+		if te.Distinct {
+			c += `DISTINCT `
+		}
+		c += te.Field
+		c += `)`
+		return c, nil
 	}
 
 	return ``, fmt.Errorf(`unsupported expression type: %T`, ex)

--- a/sqlbuilder/dialect/sqlite/sqlite.go
+++ b/sqlbuilder/dialect/sqlite/sqlite.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/column"
 	"github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/conflict"
 	"github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/filter"
+	"github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/functions"
 	"github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/internal/expr"
 	"github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/internal/params"
 )
@@ -25,6 +26,18 @@ func (m Dialect) ResolveExpr(ex expr.Expr) (string, error) {
 		} else {
 			return te.Name, nil
 		}
+
+	case functions.Count:
+		if te.All() {
+			return `COUNT(*)`, nil
+		}
+		c := `COUNT(`
+		if te.Distinct {
+			c += `DISTINCT `
+		}
+		c += te.Field
+		c += `)`
+		return c, nil
 	}
 
 	return ``, fmt.Errorf(`unsupported expression type: %T`, ex)

--- a/sqlbuilder/functions/count.go
+++ b/sqlbuilder/functions/count.go
@@ -1,0 +1,32 @@
+package functions
+
+type Count struct {
+	Field    string
+	Distinct bool
+}
+
+func CountAll() Count {
+	return Count{}
+}
+
+func CountField(f string) Count {
+	return Count{
+		Field:    f,
+		Distinct: false,
+	}
+}
+
+func CountDistinct(f string) Count {
+	return Count{
+		Field:    f,
+		Distinct: true,
+	}
+}
+
+func (c Count) Args() []any {
+	return nil
+}
+
+func (c Count) All() bool {
+	return c.Field == ``
+}

--- a/sqlbuilder/integration_test.go
+++ b/sqlbuilder/integration_test.go
@@ -164,7 +164,7 @@ func TestMySQLAutoIncrement(t *testing.T) {
 		Exec(db)
 	require.NoError(t, err)
 
-	rows, err := b.SelectFromTable(`Test1`).Fields(`A`, `B`).Query(db)
+	rows, err := b.SelectFromTable(`Test1`).Columns(`A`, `B`).Query(db)
 	require.NoError(t, err)
 
 	var (
@@ -235,7 +235,7 @@ func TestCreateTable(t *testing.T) {
 		Exec(db)
 	require.NoError(t, err)
 
-	rows, err := b.SelectFromTable(`Test1`).Fields(`A`, `B`, `C`).Query(db)
+	rows, err := b.SelectFromTable(`Test1`).Columns(`A`, `B`, `C`).Query(db)
 	require.NoError(t, err)
 	defer rows.Close()
 
@@ -272,7 +272,7 @@ func TestInsertBatches(t *testing.T) {
 
 	validateTable := func(t *testing.T, exp ...[3]any) {
 		rows, err := b.SelectFromTable(`Example`).
-			Fields(`ID`, `NumberField`, `TextField`).
+			Columns(`ID`, `NumberField`, `TextField`).
 			OrderBy(filter.OrderAsc(`ID`)).
 			Query(db)
 		require.NoError(t, err)
@@ -383,7 +383,7 @@ func TestConflicts(t *testing.T) {
 
 	validateTable := func(t *testing.T, exp ...[3]any) {
 		rows, err := b.SelectFromTable(`Example`).
-			Fields(`ID`, `NumberField`, `TextField`).
+			Columns(`ID`, `NumberField`, `TextField`).
 			OrderBy(filter.OrderAsc(`ID`)).
 			Query(db)
 		require.NoError(t, err)
@@ -519,7 +519,7 @@ func TestBasicFunction(t *testing.T) {
 	assert.EqualValues(t, 5, n)
 
 	row, err := b.SelectFromTable(`Example`).
-		Fields(`NumberField`, `TextField`).
+		Columns(`NumberField`, `TextField`).
 		Where(filter.Equals(`NumberField`, 3)).
 		QueryRow(db)
 	require.NoError(t, err)
@@ -536,7 +536,7 @@ func TestBasicFunction(t *testing.T) {
 	}
 
 	rows, err := b.SelectFromTable(`Example`).
-		Fields(`ID`, `NumberField`, `TextField`).
+		Columns(`ID`, `NumberField`, `TextField`).
 		Where(filter.In(`TextField`, `bb`, `dd`)).
 		Query(db)
 	require.NoError(t, err)
@@ -564,7 +564,7 @@ func TestBasicFunction(t *testing.T) {
 	}
 
 	rows, err = b.SelectFromTable(`Example`).
-		Fields(`ID`, `NumberField`, `TextField`).
+		Columns(`ID`, `NumberField`, `TextField`).
 		Where(filter.In(`TextField`, `bb`, `dd`)).
 		OrderBy(filter.OrderDesc(`TextField`)).
 		Limit(1).
@@ -602,7 +602,7 @@ func TestBasicFunction(t *testing.T) {
 	assert.EqualValues(t, 1, n)
 
 	row, err = b.SelectFromTable(`Example`).
-		Fields(`*`).
+		Columns(`*`).
 		Where(filter.Equals(`ID`, `a`)).
 		QueryRow(db)
 	require.NoError(t, err)
@@ -636,7 +636,7 @@ func TestBasicFunction(t *testing.T) {
 	require.NoError(t, tx.Commit())
 
 	rows, err = b.SelectFromTable(`Example`).
-		Fields(`ID`, `NumberField`, `TextField`).
+		Columns(`ID`, `NumberField`, `TextField`).
 		OrderBy(filter.OrderDesc(`NumberField`)).
 		Query(db)
 	require.NoError(t, err)

--- a/sqlbuilder/internal/expr/column.go
+++ b/sqlbuilder/internal/expr/column.go
@@ -1,0 +1,26 @@
+package expr
+
+// Column is a column literal expression. It can optionally be qualified with the database name.
+type Column struct {
+	Database string
+	Name     string
+}
+
+func NewColumn(name string) Column {
+	return NewQualifiedColumn(``, name)
+}
+
+func NewQualifiedColumn(db, name string) Column {
+	return Column{
+		Database: db,
+		Name:     name,
+	}
+}
+
+func (c Column) IsQualified() bool {
+	return c.Database != ``
+}
+
+func (c Column) Args() []any {
+	return nil
+}

--- a/sqlbuilder/internal/expr/expr.go
+++ b/sqlbuilder/internal/expr/expr.go
@@ -1,0 +1,11 @@
+package expr
+
+// Expr represents a generic SQL expression. This can take many forms: a column's name, a boolean expression
+// (like Column = ?), a function call (like COUNT(*)), etc. This is a building block for statements. Note that Expr is
+// not specific to any SQL dialect; dialects are responsible for synthesizing the specific syntax that corresponds to
+// any given expression.
+//
+// The arguments returned by an expression correspond to placeholder that are included in the resolved expression.
+type Expr interface {
+	Args() []any
+}

--- a/sqlbuilder/internal/sel/sel.go
+++ b/sqlbuilder/internal/sel/sel.go
@@ -11,16 +11,6 @@ import (
 	"github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/statement"
 )
 
-type Target interface {
-	SelectTarget() (string, error)
-}
-
-type Table string
-
-func (t Table) SelectTarget() (string, error) {
-	return string(t), nil
-}
-
 type Dialect interface {
 	SelectStmt(table string, fields ...string) (string, error)
 	SelectForUpdateStmt(table string, fields ...string) (string, error)

--- a/sqlbuilder/internal/sel/sel.go
+++ b/sqlbuilder/internal/sel/sel.go
@@ -44,7 +44,7 @@ func NewBuilder(sel Dialect, target Target) *Builder {
 	return b
 }
 
-func (b *Builder) Fields(fs ...string) *Builder {
+func (b *Builder) Columns(fs ...string) *Builder {
 	for _, f := range fs {
 		b.fields = append(b.fields, expr.NewColumn(f))
 	}

--- a/sqlbuilder/internal/sel/sel.go
+++ b/sqlbuilder/internal/sel/sel.go
@@ -51,6 +51,11 @@ func (b *Builder) Columns(fs ...string) *Builder {
 	return b
 }
 
+func (b *Builder) Fields(fs ...expr.Expr) *Builder {
+	b.fields = append(b.fields, fs...)
+	return b
+}
+
 func (b *Builder) ForUpdate() *Builder {
 	b.forUpdate = true
 	return b

--- a/sqlbuilder/internal/sel/sel.go
+++ b/sqlbuilder/internal/sel/sel.go
@@ -7,13 +7,14 @@ import (
 	"github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/filter"
 	"github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/internal/condition"
 	"github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/internal/dispatch"
+	"github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/internal/expr"
 	"github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/internal/limit"
 	"github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/statement"
 )
 
 type Dialect interface {
-	SelectStmt(table string, fields ...string) (string, error)
-	SelectForUpdateStmt(table string, fields ...string) (string, error)
+	SelectStmt(table string, fields ...expr.Expr) (string, error)
+	SelectForUpdateStmt(table string, fields ...expr.Expr) (string, error)
 	OrderBy(o filter.Order) (string, error)
 
 	limit.Limiter
@@ -22,10 +23,11 @@ type Dialect interface {
 
 type Builder struct {
 	target    Target
-	fields    []string
 	forUpdate bool
 	orderBy   *filter.Order
 	sel       Dialect
+
+	fields []expr.Expr
 
 	*condition.ConditionBuilder[*Builder]
 	*limit.LimitBuilder[*Builder]
@@ -43,7 +45,9 @@ func NewBuilder(sel Dialect, target Target) *Builder {
 }
 
 func (b *Builder) Fields(fs ...string) *Builder {
-	b.fields = append(b.fields, fs...)
+	for _, f := range fs {
+		b.fields = append(b.fields, expr.NewColumn(f))
+	}
 	return b
 }
 

--- a/sqlbuilder/internal/sel/target.go
+++ b/sqlbuilder/internal/sel/target.go
@@ -1,0 +1,11 @@
+package sel
+
+type Target interface {
+	SelectTarget() (string, error)
+}
+
+type Table string
+
+func (t Table) SelectTarget() (string, error) {
+	return string(t), nil
+}


### PR DESCRIPTION
Currently, you can only SELECT columns, but not things like `COUNT(*)`, `MAX(...)`, etc. Add support for SQL _expressions_. Implement the column literal and count expressions. Partially addresses #2, but we still need to add support for more built-in functions later.