### PR TITLE
AST Spike

### DIFF
--- a/sqlbuilder/builder.go
+++ b/sqlbuilder/builder.go
@@ -1,6 +1,9 @@
 package sqlbuilder
 
 import (
+	"io"
+
+	"github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/internal/ast"
 	"github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/internal/delete"
 	"github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/internal/insert"
 	"github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/internal/sel"
@@ -16,12 +19,17 @@ type Dialect interface {
 	table.CreateDialect
 }
 
+type Formatter interface {
+	FormatNode(w io.Writer, n ast.Node)
+}
+
 type Builder struct {
 	d        Dialect
+	f        Formatter
 	database string
 }
 
-func New(d Dialect) *Builder {
+func New(d Dialect, f Formatter) *Builder {
 	return &Builder{
 		d: d,
 	}
@@ -40,7 +48,7 @@ func (b *Builder) qualifiedTableName(table string) string {
 }
 
 func (b *Builder) SelectFrom(target sel.Target) *sel.Builder {
-	return sel.NewBuilder(b.d, target)
+	return sel.NewBuilder(b.d, b.f, target)
 }
 
 func (b *Builder) SelectFromTable(table string) *sel.Builder {

--- a/sqlbuilder/builder.go
+++ b/sqlbuilder/builder.go
@@ -32,6 +32,7 @@ type Builder struct {
 func New(d Dialect, f Formatter) *Builder {
 	return &Builder{
 		d: d,
+		f: f,
 	}
 }
 

--- a/sqlbuilder/filter/filter.go
+++ b/sqlbuilder/filter/filter.go
@@ -75,7 +75,7 @@ func (f EqualsFilter) Args() []any {
 }
 
 func (f EqualsFilter) IntoExpr() ast.Expr {
-	return ast.NewBinaryExpr(ast.NewColumn(f.Column), ast.BinaryEquals, ast.NewPlaceholderLiteral(f.Value))
+	return ast.NewBinaryExpr(ast.NewIdentifier(f.Column), ast.BinaryEquals, ast.NewPlaceholderLiteral(f.Value))
 }
 
 type NotEqualsFilter struct {
@@ -95,7 +95,7 @@ func (f NotEqualsFilter) Args() []any {
 }
 
 func (f NotEqualsFilter) IntoExpr() ast.Expr {
-	return ast.NewBinaryExpr(ast.NewColumn(f.Column), ast.BinaryNotEquals, ast.NewPlaceholderLiteral(f.Value))
+	return ast.NewBinaryExpr(ast.NewIdentifier(f.Column), ast.BinaryNotEquals, ast.NewPlaceholderLiteral(f.Value))
 }
 
 type GreaterFilter struct {
@@ -115,7 +115,7 @@ func (f GreaterFilter) Args() []any {
 }
 
 func (f GreaterFilter) IntoExpr() ast.Expr {
-	return ast.NewBinaryExpr(ast.NewColumn(f.Column), ast.BinaryGreater, ast.NewPlaceholderLiteral(f.Value))
+	return ast.NewBinaryExpr(ast.NewIdentifier(f.Column), ast.BinaryGreater, ast.NewPlaceholderLiteral(f.Value))
 }
 
 type GreaterOrEqualFilter struct {
@@ -135,7 +135,7 @@ func (f GreaterOrEqualFilter) Args() []any {
 }
 
 func (f GreaterOrEqualFilter) IntoExpr() ast.Expr {
-	return ast.NewBinaryExpr(ast.NewColumn(f.Column), ast.BinaryGraeaterOrEqual, ast.NewPlaceholderLiteral(f.Value))
+	return ast.NewBinaryExpr(ast.NewIdentifier(f.Column), ast.BinaryGraeaterOrEqual, ast.NewPlaceholderLiteral(f.Value))
 }
 
 type LessFilter struct {
@@ -155,7 +155,7 @@ func (f LessFilter) Args() []any {
 }
 
 func (f LessFilter) IntoExpr() ast.Expr {
-	return ast.NewBinaryExpr(ast.NewColumn(f.Column), ast.BinaryLess, ast.NewPlaceholderLiteral(f.Value))
+	return ast.NewBinaryExpr(ast.NewIdentifier(f.Column), ast.BinaryLess, ast.NewPlaceholderLiteral(f.Value))
 }
 
 type LessOrEqualFilter struct {
@@ -175,7 +175,7 @@ func (f LessOrEqualFilter) Args() []any {
 }
 
 func (f LessOrEqualFilter) IntoExpr() ast.Expr {
-	return ast.NewBinaryExpr(ast.NewColumn(f.Column), ast.BinaryLessOrEqual, ast.NewPlaceholderLiteral(f.Value))
+	return ast.NewBinaryExpr(ast.NewIdentifier(f.Column), ast.BinaryLessOrEqual, ast.NewPlaceholderLiteral(f.Value))
 }
 
 type InFilter struct {
@@ -199,5 +199,5 @@ func (f InFilter) IntoExpr() ast.Expr {
 	for _, val := range f.Values {
 		exprs = append(exprs, ast.NewPlaceholderLiteral(val))
 	}
-	return ast.NewBinaryExpr(ast.NewColumn(f.Column), ast.BinaryIn, ast.NewTupleLiteral(exprs...))
+	return ast.NewBinaryExpr(ast.NewIdentifier(f.Column), ast.BinaryIn, ast.NewTupleLiteral(exprs...))
 }

--- a/sqlbuilder/filter/order.go
+++ b/sqlbuilder/filter/order.go
@@ -1,11 +1,23 @@
 package filter
 
+import "github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/internal/ast"
+
 type Direction int
 
 const (
 	Ascending Direction = iota
 	Descending
 )
+
+func (d Direction) ToASTDirection() ast.OrderDirection {
+	switch d {
+	case Ascending:
+		return ast.OrderAsc
+	case Descending:
+		return ast.OrderDesc
+	}
+	panic(`unreachable`)
+}
 
 type Order struct {
 	Column    string

--- a/sqlbuilder/functions/count.go
+++ b/sqlbuilder/functions/count.go
@@ -34,5 +34,13 @@ func (c Count) All() bool {
 }
 
 func (c Count) IntoExpr() ast.Expr {
-	return ast.NewFunction(`COUNT`, ast.NewStarLiteral())
+	if c.All() {
+		return ast.NewFunction(`COUNT`, ast.NewStarLiteral())
+	}
+
+	if c.Distinct {
+		return ast.NewFunction(`COUNT`, ast.NewDistinct(ast.NewIdentifier(c.Field)))
+	}
+
+	return ast.NewFunction(`COUNT`, ast.NewIdentifier(c.Field))
 }

--- a/sqlbuilder/functions/count.go
+++ b/sqlbuilder/functions/count.go
@@ -1,5 +1,7 @@
 package functions
 
+import "github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/internal/ast"
+
 type Count struct {
 	Field    string
 	Distinct bool
@@ -29,4 +31,8 @@ func (c Count) Args() []any {
 
 func (c Count) All() bool {
 	return c.Field == ``
+}
+
+func (c Count) IntoExpr() ast.Expr {
+	return ast.NewFunction(`COUNT`, ast.NewStarLiteral())
 }

--- a/sqlbuilder/integration_test.go
+++ b/sqlbuilder/integration_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/dialect/sqlite"
 	"github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/filter"
 	"github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/functions"
+	"github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/internal/formatter"
 	"github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/statement"
 	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/mattn/go-sqlite3"
@@ -111,14 +112,14 @@ func getDatabaseAndBuilder(t *testing.T) (*sql.DB, *sqlbuilder.Builder) {
 		t.Log(`--- Using MySQL database for testing ---`)
 
 		db := openMySQLDatabase(t, true)
-		b := sqlbuilder.New(mysql.Dialect{})
+		b := sqlbuilder.New(mysql.Dialect{}, formatter.Mysql{})
 		return db, b
 	}
 
 	t.Log(`--- Using SQLite database for testing ---`)
 
 	db := openSQLiteDatabase(t, true)
-	b := sqlbuilder.New(sqlite.Dialect{})
+	b := sqlbuilder.New(sqlite.Dialect{}, formatter.Sqlite{})
 	return db, b
 }
 
@@ -127,14 +128,14 @@ func getDatabaseAndBuilderWithoutTable(t *testing.T) (*sql.DB, *sqlbuilder.Build
 		t.Log(`--- Using MySQL database for testing ---`)
 
 		db := openMySQLDatabase(t, false)
-		b := sqlbuilder.New(mysql.Dialect{})
+		b := sqlbuilder.New(mysql.Dialect{}, formatter.Mysql{})
 		return db, b
 	}
 
 	t.Log(`--- Using SQLite database for testing ---`)
 
 	db := openSQLiteDatabase(t, false)
-	b := sqlbuilder.New(sqlite.Dialect{})
+	b := sqlbuilder.New(sqlite.Dialect{}, formatter.Sqlite{})
 	return db, b
 }
 
@@ -144,7 +145,7 @@ func TestMySQLAutoIncrement(t *testing.T) {
 	}
 
 	db := openMySQLDatabase(t, false)
-	b := sqlbuilder.New(mysql.Dialect{})
+	b := sqlbuilder.New(mysql.Dialect{}, formatter.Mysql{})
 
 	stmt, err := b.CreateTable(`Test1`).
 		Columns(

--- a/sqlbuilder/internal/ast/args.go
+++ b/sqlbuilder/internal/ast/args.go
@@ -1,13 +1,9 @@
 package ast
 
-func Visit(n Node, fn func(n Node) bool) {
-	n.AcceptVisitor(fn)
-}
-
 func GetArgs(n Node) []any {
 	var args []any
 
-	Visit(n, func(n Node) bool {
+	n.AcceptVisitor(func(n Node) bool {
 		ph, ok := n.(*PlaceholderLiteral)
 		if !ok {
 			// Keep traversing the tree

--- a/sqlbuilder/internal/ast/column.go
+++ b/sqlbuilder/internal/ast/column.go
@@ -1,7 +1,20 @@
 package ast
 
 type Column struct {
-	baseExpr
-
+	Expr
 	Name string
+}
+
+func NewColumn(name string) *Column {
+	return &Column{
+		Name: name,
+	}
+}
+
+func (c *Column) AcceptVisitor(fn func(Node) bool) {
+	fn(c)
+}
+
+func (c *Column) IntoExpr() Expr {
+	return c
 }

--- a/sqlbuilder/internal/ast/column.go
+++ b/sqlbuilder/internal/ast/column.go
@@ -1,20 +1,20 @@
 package ast
 
-type Column struct {
+type Identifier struct {
 	Expr
 	Name string
 }
 
-func NewColumn(name string) *Column {
-	return &Column{
+func NewColumn(name string) *Identifier {
+	return &Identifier{
 		Name: name,
 	}
 }
 
-func (c *Column) AcceptVisitor(fn func(Node) bool) {
+func (c *Identifier) AcceptVisitor(fn func(Node) bool) {
 	fn(c)
 }
 
-func (c *Column) IntoExpr() Expr {
+func (c *Identifier) IntoExpr() Expr {
 	return c
 }

--- a/sqlbuilder/internal/ast/column.go
+++ b/sqlbuilder/internal/ast/column.go
@@ -1,0 +1,7 @@
+package ast
+
+type Column struct {
+	baseExpr
+
+	Name string
+}

--- a/sqlbuilder/internal/ast/distinct.go
+++ b/sqlbuilder/internal/ast/distinct.go
@@ -1,0 +1,24 @@
+package ast
+
+type Distinct struct {
+	Expr
+	Exprs []Expr
+}
+
+func NewDistinct(exprs ...IntoExpr) *Distinct {
+	return &Distinct{
+		Exprs: IntoExprs(exprs...),
+	}
+}
+
+func (d *Distinct) AcceptVisitor(fn func(Node) bool) {
+	if fn(d) {
+		for _, expr := range d.Exprs {
+			fn(expr)
+		}
+	}
+}
+
+func (d *Distinct) IntoExpr() Expr {
+	return d
+}

--- a/sqlbuilder/internal/ast/expr.go
+++ b/sqlbuilder/internal/ast/expr.go
@@ -4,17 +4,27 @@ type IntoExpr interface {
 	IntoExpr() Expr
 }
 
+func IntoExprs(intos ...IntoExpr) []Expr {
+	res := make([]Expr, 0, len(intos))
+	for _, i := range intos {
+		res = append(res, i.IntoExpr())
+	}
+	return res
+}
+
+func None() intoNone {
+	return intoNone{}
+}
+
+type intoNone struct{}
+
+func (intoNone) IntoExpr() Expr {
+	return nil
+}
+
 type Expr interface {
 	Node
 	expr()
-}
-
-type baseExpr struct {
-	Expr
-}
-
-func (be baseExpr) IntoExpr() Expr {
-	return be
 }
 
 type BinaryExprOperator int
@@ -27,6 +37,8 @@ const (
 	BinaryLess
 	BinaryLessOrEqual
 	BinaryIn
+	BinaryAnd
+	BinaryOr
 )
 
 type BinaryExpr struct {
@@ -34,4 +46,23 @@ type BinaryExpr struct {
 	Left  Expr
 	Op    BinaryExprOperator
 	Right Expr
+}
+
+func NewBinaryExpr(left IntoExpr, op BinaryExprOperator, right IntoExpr) *BinaryExpr {
+	return &BinaryExpr{
+		Left:  left.IntoExpr(),
+		Op:    op,
+		Right: right.IntoExpr(),
+	}
+}
+
+func (b *BinaryExpr) IntoExpr() Expr {
+	return b
+}
+
+func (b *BinaryExpr) AcceptVisitor(fn func(Node) bool) {
+	if fn(b) {
+		b.Left.AcceptVisitor(fn)
+		b.Right.AcceptVisitor(fn)
+	}
 }

--- a/sqlbuilder/internal/ast/expr.go
+++ b/sqlbuilder/internal/ast/expr.go
@@ -1,0 +1,37 @@
+package ast
+
+type IntoExpr interface {
+	IntoExpr() Expr
+}
+
+type Expr interface {
+	Node
+	expr()
+}
+
+type baseExpr struct {
+	Expr
+}
+
+func (be baseExpr) IntoExpr() Expr {
+	return be
+}
+
+type BinaryExprOperator int
+
+const (
+	BinaryEquals BinaryExprOperator = iota
+	BinaryNotEquals
+	BinaryGreater
+	BinaryGraeaterOrEqual
+	BinaryLess
+	BinaryLessOrEqual
+	BinaryIn
+)
+
+type BinaryExpr struct {
+	Expr
+	Left  Expr
+	Op    BinaryExprOperator
+	Right Expr
+}

--- a/sqlbuilder/internal/ast/function.go
+++ b/sqlbuilder/internal/ast/function.go
@@ -1,0 +1,22 @@
+package ast
+
+type Function struct {
+	Expr
+	Name string
+	Args []Expr
+}
+
+func NewFunction(name string, args ...IntoExpr) *Function {
+	return &Function{
+		Name: name,
+		Args: IntoExprs(args...),
+	}
+}
+
+func (f *Function) AcceptVisitor(fn func(Node) bool) {
+	if fn(f) {
+		for _, a := range f.Args {
+			a.AcceptVisitor(fn)
+		}
+	}
+}

--- a/sqlbuilder/internal/ast/identifier.go
+++ b/sqlbuilder/internal/ast/identifier.go
@@ -5,7 +5,7 @@ type Identifier struct {
 	Name string
 }
 
-func NewColumn(name string) *Identifier {
+func NewIdentifier(name string) *Identifier {
 	return &Identifier{
 		Name: name,
 	}

--- a/sqlbuilder/internal/ast/limit.go
+++ b/sqlbuilder/internal/ast/limit.go
@@ -1,7 +1,26 @@
 package ast
 
 type Limit struct {
-	Node
+	Expr
 	Offset Expr
 	Count  Expr
+}
+
+func NewLimit(offset, count IntoExpr) *Limit {
+	return &Limit{
+		Offset: offset.IntoExpr(),
+		Count:  count.IntoExpr(),
+	}
+}
+
+func (l *Limit) AcceptVisitor(fn func(Node) bool) {
+	if l == nil {
+		return
+	}
+	if fn(l) {
+		if l.Offset != nil {
+			l.Offset.AcceptVisitor(fn)
+		}
+		l.Count.AcceptVisitor(fn)
+	}
 }

--- a/sqlbuilder/internal/ast/limit.go
+++ b/sqlbuilder/internal/ast/limit.go
@@ -1,0 +1,7 @@
+package ast
+
+type Limit struct {
+	Node
+	Offset Expr
+	Count  Expr
+}

--- a/sqlbuilder/internal/ast/lit.go
+++ b/sqlbuilder/internal/ast/lit.go
@@ -1,0 +1,59 @@
+package ast
+
+type PlaceholderLiteral struct {
+	Expr
+	For any
+}
+
+func NewPlaceholderLiteral(val any) *PlaceholderLiteral {
+	return &PlaceholderLiteral{
+		For: val,
+	}
+}
+
+func (l *PlaceholderLiteral) IntoExpr() Expr {
+	return l
+}
+
+func (l *PlaceholderLiteral) PlaceholderValue() any {
+	return l.For
+}
+
+func (l *PlaceholderLiteral) AcceptVisitor(fn func(Node) bool) {
+	fn(l)
+}
+
+type IntegerLiteral struct {
+	Expr
+	Value int
+}
+
+func NewIntegerLiteral(val int) *IntegerLiteral {
+	return &IntegerLiteral{
+		Value: val,
+	}
+}
+
+func (l *IntegerLiteral) IntoExpr() Expr {
+	return l
+}
+
+func (l *IntegerLiteral) AcceptVisitor(fn func(Node) bool) {
+	fn(l)
+}
+
+type StarLiteral struct {
+	Expr
+}
+
+func NewStarLiteral() *StarLiteral {
+	return &StarLiteral{}
+}
+
+func (l *StarLiteral) IntoExpr() Expr {
+	return l
+}
+
+func (l *StarLiteral) AcceptVisitor(fn func(Node) bool) {
+	fn(l)
+}

--- a/sqlbuilder/internal/ast/lock.go
+++ b/sqlbuilder/internal/ast/lock.go
@@ -1,0 +1,14 @@
+package ast
+
+type LockKind int
+
+const (
+	NoLock LockKind = iota
+	SharedLock
+	ForUpdateLock
+)
+
+type Lock struct {
+	Node
+	Kind LockKind
+}

--- a/sqlbuilder/internal/ast/lock.go
+++ b/sqlbuilder/internal/ast/lock.go
@@ -12,3 +12,7 @@ type Lock struct {
 	Node
 	Kind LockKind
 }
+
+func (l *Lock) AcceptVisitor(fn func(Node) bool) {
+	fn(l)
+}

--- a/sqlbuilder/internal/ast/node.go
+++ b/sqlbuilder/internal/ast/node.go
@@ -1,5 +1,5 @@
 package ast
 
 type Node interface {
-	node()
+	AcceptVisitor(fn func(n Node) bool)
 }

--- a/sqlbuilder/internal/ast/node.go
+++ b/sqlbuilder/internal/ast/node.go
@@ -1,0 +1,5 @@
+package ast
+
+type Node interface {
+	node()
+}

--- a/sqlbuilder/internal/ast/order.go
+++ b/sqlbuilder/internal/ast/order.go
@@ -12,7 +12,17 @@ type Order struct {
 	Direction OrderDirection
 }
 
+func NewOrder(expr IntoExpr, dir OrderDirection) Order {
+	return Order{
+		Expr:      expr.IntoExpr(),
+		Direction: dir,
+	}
+}
+
 type OrderBy struct {
 	Orders []Order
-	Node
+}
+
+func (o *OrderBy) AcceptVisitor(fn func(Node) bool) {
+	fn(o)
 }

--- a/sqlbuilder/internal/ast/order.go
+++ b/sqlbuilder/internal/ast/order.go
@@ -1,0 +1,18 @@
+package ast
+
+type OrderDirection int
+
+const (
+	OrderAsc OrderDirection = iota
+	OrderDesc
+)
+
+type Order struct {
+	Expr      Expr
+	Direction OrderDirection
+}
+
+type OrderBy struct {
+	Orders []Order
+	Node
+}

--- a/sqlbuilder/internal/ast/select.go
+++ b/sqlbuilder/internal/ast/select.go
@@ -1,0 +1,52 @@
+package ast
+
+type Select struct {
+	From    TableExpr
+	Exprs   []Expr
+	Where   *Where
+	Limit   *Limit
+	OrderBy *OrderBy
+	Lock    *Lock
+}
+
+func NewSelect(from TableExpr, exprs ...IntoExpr) *Select {
+	es := make([]Expr, 0, len(exprs))
+	for _, e := range exprs {
+		es = append(es, e.IntoExpr())
+	}
+	return &Select{
+		From:  from,
+		Exprs: es,
+	}
+}
+
+func (s *Select) WithWhere(expr IntoExpr) *Select {
+	s.Where = &Where{
+		Expr: expr.IntoExpr(),
+	}
+	return s
+}
+
+func (s *Select) WithOrders(os ...Order) *Select {
+	if s.OrderBy == nil {
+		s.OrderBy = &OrderBy{
+			Orders: os,
+		}
+		return s
+	}
+	s.OrderBy.Orders = append(s.OrderBy.Orders, os...)
+	return s
+}
+
+func (s *Select) WithLimit(offset, count IntoExpr) *Select {
+	s.Limit = &Limit{
+		Offset: offset.IntoExpr(),
+		Count:  count.IntoExpr(),
+	}
+	return s
+}
+
+func (s *Select) WithLock(k LockKind) *Select {
+	s.Lock = &Lock{Kind: k}
+	return s
+}

--- a/sqlbuilder/internal/ast/select.go
+++ b/sqlbuilder/internal/ast/select.go
@@ -1,6 +1,7 @@
 package ast
 
 type Select struct {
+	Node
 	From    TableExpr
 	Exprs   []Expr
 	Where   *Where

--- a/sqlbuilder/internal/ast/table.go
+++ b/sqlbuilder/internal/ast/table.go
@@ -1,17 +1,55 @@
 package ast
 
+type IntoTableExpr interface {
+	IntoTableExpr() TableExpr
+}
+
 type TableExpr interface {
 	Expr
 	tableExpr()
 }
 
-type baseTableExpr struct {
-	baseExpr
-}
-
 type TableName struct {
-	baseTableExpr
+	TableExpr
 
 	Name      string
 	Qualifier string
+}
+
+func NewTableName(name string) *TableName {
+	return &TableName{
+		Name: name,
+	}
+}
+
+func (t *TableName) IntoExpr() Expr {
+	return t
+}
+
+func (t *TableName) AcceptVisitor(fn func(Node) bool) {
+	fn(t)
+}
+
+type TupleLiteral struct {
+	TableExpr
+
+	Values []Expr
+}
+
+func NewTupleLiteral(values ...IntoExpr) *TupleLiteral {
+	return &TupleLiteral{
+		Values: IntoExprs(values...),
+	}
+}
+
+func (t *TupleLiteral) IntoExpr() Expr {
+	return t
+}
+
+func (t *TupleLiteral) AcceptVisitor(fn func(Node) bool) {
+	if fn(t) {
+		for _, v := range t.Values {
+			v.AcceptVisitor(fn)
+		}
+	}
 }

--- a/sqlbuilder/internal/ast/table.go
+++ b/sqlbuilder/internal/ast/table.go
@@ -1,0 +1,17 @@
+package ast
+
+type TableExpr interface {
+	Expr
+	tableExpr()
+}
+
+type baseTableExpr struct {
+	baseExpr
+}
+
+type TableName struct {
+	baseTableExpr
+
+	Name      string
+	Qualifier string
+}

--- a/sqlbuilder/internal/ast/walk.go
+++ b/sqlbuilder/internal/ast/walk.go
@@ -1,0 +1,21 @@
+package ast
+
+func Visit(n Node, fn func(n Node) bool) {
+	n.AcceptVisitor(fn)
+}
+
+func GetArgs(n Node) []any {
+	var args []any
+
+	Visit(n, func(n Node) bool {
+		ph, ok := n.(*PlaceholderLiteral)
+		if !ok {
+			// Keep traversing the tree
+			return true
+		}
+		args = append(args, ph.For)
+		return false
+	})
+
+	return args
+}

--- a/sqlbuilder/internal/ast/where.go
+++ b/sqlbuilder/internal/ast/where.go
@@ -1,6 +1,14 @@
 package ast
 
 type Where struct {
-	Node
 	Expr Expr
+}
+
+func (w *Where) AcceptVisitor(fn func(Node) bool) {
+	if w == nil {
+		return
+	}
+	if fn(w) {
+		w.Expr.AcceptVisitor(fn)
+	}
 }

--- a/sqlbuilder/internal/ast/where.go
+++ b/sqlbuilder/internal/ast/where.go
@@ -1,0 +1,5 @@
+package ast
+
+type Where struct {
+	Expr Expr
+}

--- a/sqlbuilder/internal/ast/where.go
+++ b/sqlbuilder/internal/ast/where.go
@@ -1,5 +1,6 @@
 package ast
 
 type Where struct {
+	Node
 	Expr Expr
 }

--- a/sqlbuilder/internal/condition/condition.go
+++ b/sqlbuilder/internal/condition/condition.go
@@ -1,6 +1,9 @@
 package condition
 
-import "github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/filter"
+import (
+	"github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/filter"
+	"github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/internal/ast"
+)
 
 type Conditioner interface {
 	Condition(f filter.Filter) (string, error)
@@ -46,4 +49,11 @@ func (b *ConditionBuilder[T]) SQLAndArgs(c Conditioner) (string, []any, error) {
 		return ``, nil, err
 	}
 	return cond, b.f.Args(), nil
+}
+
+func (b *ConditionBuilder[T]) IntoExpr() ast.Expr {
+	if b.f == nil {
+		return nil
+	}
+	return b.f.IntoExpr()
 }

--- a/sqlbuilder/internal/expr/column.go
+++ b/sqlbuilder/internal/expr/column.go
@@ -9,7 +9,7 @@ type Column struct {
 }
 
 func (c Column) IntoExpr() ast.Expr {
-	return ast.NewColumn(c.Name)
+	return ast.NewIdentifier(c.Name)
 }
 
 func NewColumn(name string) Column {

--- a/sqlbuilder/internal/expr/column.go
+++ b/sqlbuilder/internal/expr/column.go
@@ -1,9 +1,15 @@
 package expr
 
+import "github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/internal/ast"
+
 // Column is a column literal expression. It can optionally be qualified with the database name.
 type Column struct {
 	Database string
 	Name     string
+}
+
+func (c Column) IntoExpr() ast.Expr {
+	return ast.NewColumn(c.Name)
 }
 
 func NewColumn(name string) Column {

--- a/sqlbuilder/internal/formatter/mysql.go
+++ b/sqlbuilder/internal/formatter/mysql.go
@@ -33,6 +33,8 @@ func (m Mysql) FormatNode(w io.Writer, n ast.Node) {
 		m.formatIntegerLiteral(w, tn)
 	case *ast.OrderBy:
 		m.formatOrderBy(w, tn)
+	case *ast.Function:
+		m.formatFunction(w, tn)
 	default:
 		panic(fmt.Sprintf(`unexpected node: %T`, n))
 	}
@@ -66,6 +68,15 @@ func (m Mysql) formatSelect(w io.Writer, s *ast.Select) {
 		fmt.Fprint(w, ` `)
 		m.FormatNode(w, s.Lock)
 	}
+}
+
+func (m Mysql) formatFunction(w io.Writer, f *ast.Function) {
+	fmt.Fprint(w, f.Name)
+	fmt.Fprint(w, `(`)
+	for _, arg := range f.Args {
+		m.FormatNode(w, arg)
+	}
+	fmt.Fprint(w, `)`)
 }
 
 func (m Mysql) formatIntegerLiteral(w io.Writer, l *ast.IntegerLiteral) {

--- a/sqlbuilder/internal/formatter/mysql.go
+++ b/sqlbuilder/internal/formatter/mysql.go
@@ -1,0 +1,114 @@
+package formatter
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/internal/ast"
+)
+
+type Mysql struct{}
+
+func (m Mysql) FormatNode(w io.Writer, n ast.Node) {
+	switch tn := n.(type) {
+	case *ast.Select:
+		m.formatSelect(w, tn)
+	case *ast.TableName:
+		m.formatTableName(w, tn)
+	case *ast.Column:
+		m.formatColumn(w, tn)
+	case *ast.Limit:
+		m.formatLimit(w, tn)
+	case *ast.Lock:
+		m.formatLock(w, tn)
+	case ast.BinaryExpr:
+		m.formatBinaryExpr(w, tn)
+	}
+	panic(fmt.Sprintf(`unexpected node: %T`, n))
+}
+
+func (m Mysql) formatSelect(w io.Writer, s *ast.Select) {
+	fmt.Fprint(w, `SELECT `)
+	for i, expr := range s.Exprs {
+		m.FormatNode(w, expr)
+		if i < len(s.Exprs)-1 {
+			fmt.Fprint(w, `,`)
+		}
+	}
+
+	fmt.Fprint(w, ` FROM `)
+	m.FormatNode(w, s.From)
+
+	if s.Where != nil {
+		fmt.Fprint(w, ` `)
+		m.FormatNode(w, s.Where)
+	}
+	if s.OrderBy != nil {
+		fmt.Fprint(w, ` `)
+		m.FormatNode(w, s.OrderBy)
+	}
+	if s.Limit != nil {
+		fmt.Fprint(w, ` `)
+		m.FormatNode(w, s.Limit)
+	}
+	if s.Lock != nil {
+		fmt.Fprint(w, ` `)
+		m.FormatNode(w, s.Lock)
+	}
+}
+
+func (m Mysql) formatLock(w io.Writer, l *ast.Lock) {
+	if l.Kind == ast.NoLock {
+		return
+	}
+	fmt.Fprint(w, `FOR `)
+	switch l.Kind {
+	case ast.SharedLock:
+		fmt.Fprint(w, `SHARE`)
+	case ast.ForUpdateLock:
+		fmt.Fprint(w, `UPDATE`)
+	}
+}
+
+func (m Mysql) formatLimit(w io.Writer, l *ast.Limit) {
+	fmt.Fprint(w, `LIMIT `)
+	if l.Offset != nil {
+		m.FormatNode(w, l.Offset)
+		fmt.Fprint(w, `, `)
+	}
+	m.FormatNode(w, l.Count)
+}
+
+func (m Mysql) formatColumn(w io.Writer, c *ast.Column) {
+	fmt.Fprint(w, c.Name)
+}
+
+func (m Mysql) formatTableName(w io.Writer, tn *ast.TableName) {
+	if tn.Qualifier != `` {
+		fmt.Fprintf(w, `%s.`, tn.Qualifier)
+	}
+	fmt.Fprint(w, tn.Name)
+}
+
+func (m Mysql) formatBinaryExpr(w io.Writer, bin ast.BinaryExpr) {
+	m.FormatNode(w, bin.Left)
+
+	switch bin.Op {
+	case ast.BinaryEquals:
+		fmt.Fprint(w, ` = `)
+	case ast.BinaryNotEquals:
+		fmt.Fprint(w, ` != `)
+	case ast.BinaryGreater:
+		fmt.Fprint(w, ` > `)
+	case ast.BinaryGraeaterOrEqual:
+		fmt.Fprint(w, ` >= `)
+	case ast.BinaryLess:
+		fmt.Fprint(w, ` < `)
+	case ast.BinaryLessOrEqual:
+		fmt.Fprint(w, ` <= `)
+	case ast.BinaryIn:
+		fmt.Fprint(w, ` IN `)
+	}
+
+	m.FormatNode(w, bin.Right)
+}

--- a/sqlbuilder/internal/formatter/mysql.go
+++ b/sqlbuilder/internal/formatter/mysql.go
@@ -15,8 +15,8 @@ func (m Mysql) FormatNode(w io.Writer, n ast.Node) {
 		m.formatSelect(w, tn)
 	case *ast.TableName:
 		m.formatTableName(w, tn)
-	case *ast.Column:
-		m.formatColumn(w, tn)
+	case *ast.Identifier:
+		m.formatIdentifier(w, tn)
 	case *ast.Limit:
 		m.formatLimit(w, tn)
 	case *ast.Lock:
@@ -144,7 +144,7 @@ func (m Mysql) formatLimit(w io.Writer, l *ast.Limit) {
 	m.FormatNode(w, l.Count)
 }
 
-func (m Mysql) formatColumn(w io.Writer, c *ast.Column) {
+func (m Mysql) formatIdentifier(w io.Writer, c *ast.Identifier) {
 	fmt.Fprint(w, c.Name)
 }
 

--- a/sqlbuilder/internal/formatter/mysql.go
+++ b/sqlbuilder/internal/formatter/mysql.go
@@ -35,6 +35,8 @@ func (m Mysql) FormatNode(w io.Writer, n ast.Node) {
 		m.formatOrderBy(w, tn)
 	case *ast.Function:
 		m.formatFunction(w, tn)
+	case *ast.StarLiteral:
+		fmt.Fprint(w, "*")
 	default:
 		panic(fmt.Sprintf(`unexpected node: %T`, n))
 	}

--- a/sqlbuilder/internal/formatter/sqlite.go
+++ b/sqlbuilder/internal/formatter/sqlite.go
@@ -37,6 +37,8 @@ func (s Sqlite) FormatNode(w io.Writer, n ast.Node) {
 		s.formatFunction(w, tn)
 	case *ast.StarLiteral:
 		fmt.Fprint(w, "*")
+	case *ast.Distinct:
+		s.formatDistinct(w, tn)
 	default:
 		panic(fmt.Sprintf(`unexpected node: %T`, n))
 	}
@@ -167,4 +169,9 @@ func (s Sqlite) formatBinaryExpr(w io.Writer, bin *ast.BinaryExpr) {
 	}
 
 	s.FormatNode(w, bin.Right)
+}
+
+func (s Sqlite) formatDistinct(w io.Writer, d *ast.Distinct) {
+	fmt.Fprint(w, `DISTINCT `)
+	formatCommaDelimited(w, s, d.Exprs...)
 }

--- a/sqlbuilder/internal/formatter/sqlite.go
+++ b/sqlbuilder/internal/formatter/sqlite.go
@@ -33,6 +33,8 @@ func (s Sqlite) FormatNode(w io.Writer, n ast.Node) {
 		s.formatIntegerLiteral(w, tn)
 	case *ast.OrderBy:
 		s.formatOrderBy(w, tn)
+	case *ast.Function:
+		s.formatFunction(w, tn)
 	default:
 		panic(fmt.Sprintf(`unexpected node: %T`, n))
 	}
@@ -66,6 +68,15 @@ func (s Sqlite) formatSelect(w io.Writer, sl *ast.Select) {
 		fmt.Fprint(w, ` `)
 		s.FormatNode(w, sl.Lock)
 	}
+}
+
+func (s Sqlite) formatFunction(w io.Writer, f *ast.Function) {
+	fmt.Fprint(w, f.Name)
+	fmt.Fprint(w, `(`)
+	for _, arg := range f.Args {
+		s.FormatNode(w, arg)
+	}
+	fmt.Fprint(w, `)`)
 }
 
 func (s Sqlite) formatIntegerLiteral(w io.Writer, l *ast.IntegerLiteral) {

--- a/sqlbuilder/internal/formatter/sqlite.go
+++ b/sqlbuilder/internal/formatter/sqlite.go
@@ -1,0 +1,157 @@
+package formatter
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/internal/ast"
+)
+
+type Sqlite struct{}
+
+func (s Sqlite) FormatNode(w io.Writer, n ast.Node) {
+	switch tn := n.(type) {
+	case *ast.Select:
+		s.formatSelect(w, tn)
+	case *ast.TableName:
+		s.formatTableName(w, tn)
+	case *ast.Column:
+		s.formatColumn(w, tn)
+	case *ast.Limit:
+		s.formatLimit(w, tn)
+	case *ast.Lock:
+		s.formatLock(w, tn)
+	case *ast.Where:
+		s.formatWhere(w, tn)
+	case *ast.BinaryExpr:
+		s.formatBinaryExpr(w, tn)
+	case *ast.PlaceholderLiteral:
+		s.formatPlaceholderLiteral(w, tn)
+	case *ast.TupleLiteral:
+		s.formatTupleLiteral(w, tn)
+	case *ast.IntegerLiteral:
+		s.formatIntegerLiteral(w, tn)
+	case *ast.OrderBy:
+		s.formatOrderBy(w, tn)
+	default:
+		panic(fmt.Sprintf(`unexpected node: %T`, n))
+	}
+}
+
+func (s Sqlite) formatSelect(w io.Writer, sl *ast.Select) {
+	fmt.Fprint(w, `SELECT `)
+	for i, expr := range sl.Exprs {
+		s.FormatNode(w, expr)
+		if i < len(sl.Exprs)-1 {
+			fmt.Fprint(w, `,`)
+		}
+	}
+
+	fmt.Fprint(w, ` FROM `)
+	s.FormatNode(w, sl.From)
+
+	if sl.Where != nil {
+		fmt.Fprint(w, ` `)
+		s.FormatNode(w, sl.Where)
+	}
+	if sl.OrderBy != nil {
+		fmt.Fprint(w, ` `)
+		s.FormatNode(w, sl.OrderBy)
+	}
+	if sl.Limit != nil {
+		fmt.Fprint(w, ` `)
+		s.FormatNode(w, sl.Limit)
+	}
+	if sl.Lock != nil {
+		fmt.Fprint(w, ` `)
+		s.FormatNode(w, sl.Lock)
+	}
+}
+
+func (s Sqlite) formatIntegerLiteral(w io.Writer, l *ast.IntegerLiteral) {
+	fmt.Fprintf(w, `%d`, l.Value)
+}
+
+func (s Sqlite) formatTupleLiteral(w io.Writer, t *ast.TupleLiteral) {
+	fmt.Fprint(w, `(`)
+	for i, val := range t.Values {
+		s.FormatNode(w, val)
+		if i < len(t.Values)-1 {
+			fmt.Fprint(w, `,`)
+		}
+	}
+	fmt.Fprint(w, `)`)
+}
+
+func (s Sqlite) formatPlaceholderLiteral(w io.Writer, _ *ast.PlaceholderLiteral) {
+	fmt.Fprint(w, `?`)
+}
+
+func (s Sqlite) formatWhere(w io.Writer, wh *ast.Where) {
+	fmt.Fprint(w, `WHERE `)
+	s.FormatNode(w, wh.Expr)
+}
+
+func (s Sqlite) formatOrderBy(w io.Writer, o *ast.OrderBy) {
+	fmt.Fprint(w, `ORDER BY `)
+	for i, ord := range o.Orders {
+		s.FormatNode(w, ord.Expr)
+		switch ord.Direction {
+		case ast.OrderAsc:
+			fmt.Fprint(w, ` ASC`)
+		case ast.OrderDesc:
+			fmt.Fprint(w, ` DESC`)
+		}
+
+		if i < len(o.Orders)-1 {
+			fmt.Fprint(w, `,`)
+		}
+	}
+}
+
+func (s Sqlite) formatLock(w io.Writer, l *ast.Lock) {
+	// SQLite doesn't support locking. It doesn't support multiple concurrent transactions, so every select is more or less equivalent to MySQL's FOR UPDATE.
+}
+
+func (s Sqlite) formatLimit(w io.Writer, l *ast.Limit) {
+	fmt.Fprint(w, `LIMIT `)
+	if l.Offset != nil {
+		s.FormatNode(w, l.Offset)
+		fmt.Fprint(w, `, `)
+	}
+	s.FormatNode(w, l.Count)
+}
+
+func (s Sqlite) formatColumn(w io.Writer, c *ast.Column) {
+	fmt.Fprint(w, c.Name)
+}
+
+func (s Sqlite) formatTableName(w io.Writer, tn *ast.TableName) {
+	if tn.Qualifier != `` {
+		fmt.Fprintf(w, `%s.`, tn.Qualifier)
+	}
+	fmt.Fprint(w, tn.Name)
+}
+
+func (s Sqlite) formatBinaryExpr(w io.Writer, bin *ast.BinaryExpr) {
+	s.FormatNode(w, bin.Left)
+
+	switch bin.Op {
+	case ast.BinaryEquals:
+		fmt.Fprint(w, ` = `)
+	case ast.BinaryNotEquals:
+		fmt.Fprint(w, ` != `)
+	case ast.BinaryGreater:
+		fmt.Fprint(w, ` > `)
+	case ast.BinaryGraeaterOrEqual:
+		fmt.Fprint(w, ` >= `)
+	case ast.BinaryLess:
+		fmt.Fprint(w, ` < `)
+	case ast.BinaryLessOrEqual:
+		fmt.Fprint(w, ` <= `)
+	case ast.BinaryIn:
+		fmt.Fprint(w, ` IN `)
+	}
+
+	s.FormatNode(w, bin.Right)
+}

--- a/sqlbuilder/internal/formatter/sqlite.go
+++ b/sqlbuilder/internal/formatter/sqlite.go
@@ -15,8 +15,8 @@ func (s Sqlite) FormatNode(w io.Writer, n ast.Node) {
 		s.formatSelect(w, tn)
 	case *ast.TableName:
 		s.formatTableName(w, tn)
-	case *ast.Column:
-		s.formatColumn(w, tn)
+	case *ast.Identifier:
+		s.formatIdentifier(w, tn)
 	case *ast.Limit:
 		s.formatLimit(w, tn)
 	case *ast.Lock:
@@ -135,7 +135,7 @@ func (s Sqlite) formatLimit(w io.Writer, l *ast.Limit) {
 	s.FormatNode(w, l.Count)
 }
 
-func (s Sqlite) formatColumn(w io.Writer, c *ast.Column) {
+func (s Sqlite) formatIdentifier(w io.Writer, c *ast.Identifier) {
 	fmt.Fprint(w, c.Name)
 }
 

--- a/sqlbuilder/internal/formatter/sqlite.go
+++ b/sqlbuilder/internal/formatter/sqlite.go
@@ -35,6 +35,8 @@ func (s Sqlite) FormatNode(w io.Writer, n ast.Node) {
 		s.formatOrderBy(w, tn)
 	case *ast.Function:
 		s.formatFunction(w, tn)
+	case *ast.StarLiteral:
+		fmt.Fprint(w, "*")
 	default:
 		panic(fmt.Sprintf(`unexpected node: %T`, n))
 	}

--- a/sqlbuilder/internal/limit/limit.go
+++ b/sqlbuilder/internal/limit/limit.go
@@ -1,5 +1,7 @@
 package limit
 
+import "github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/internal/ast"
+
 type Limiter interface {
 	Limit() (string, error)
 }
@@ -36,4 +38,11 @@ func (b *LimitBuilder[T]) SQLAndArgs(l Limiter) (string, []any, error) {
 		return ``, nil, err
 	}
 	return lim, []any{*b.limit}, nil
+}
+
+func (b *LimitBuilder[T]) OffsetAndLimit() (ast.IntoExpr, ast.IntoExpr) {
+	if b.limit == nil {
+		return nil, nil
+	}
+	return ast.None(), ast.NewIntegerLiteral(*b.limit)
 }

--- a/sqlbuilder/internal/sel/sel.go
+++ b/sqlbuilder/internal/sel/sel.go
@@ -54,7 +54,7 @@ func NewBuilder(sel Dialect, f Formatter, target Target) *Builder {
 
 func (b *Builder) Columns(fs ...string) *Builder {
 	for _, f := range fs {
-		b.fields = append(b.fields, ast.NewColumn(f))
+		b.fields = append(b.fields, ast.NewIdentifier(f))
 	}
 	return b
 }
@@ -83,7 +83,7 @@ func (b *Builder) Build() (statement.Statement, error) {
 	n.WithLimit(offset, limit)
 
 	if b.orderBy != nil {
-		n.WithOrders(ast.NewOrder(ast.NewColumn(b.orderBy.Column), b.orderBy.Direction.ToASTDirection()))
+		n.WithOrders(ast.NewOrder(ast.NewIdentifier(b.orderBy.Column), b.orderBy.Direction.ToASTDirection()))
 	}
 
 	if b.forUpdate {

--- a/sqlbuilder/internal/sel/target.go
+++ b/sqlbuilder/internal/sel/target.go
@@ -1,10 +1,17 @@
 package sel
 
+import "github.com/cszczepaniak/go-sqlbuilder/sqlbuilder/internal/ast"
+
 type Target interface {
 	SelectTarget() (string, error)
+	ast.IntoTableExpr
 }
 
 type Table string
+
+func (t Table) IntoTableExpr() ast.TableExpr {
+	return ast.NewTableName(string(t))
+}
 
 func (t Table) SelectTarget() (string, error) {
 	return string(t), nil


### PR DESCRIPTION
It would be more robust and easier to extend if we model SQL queries as an AST, then walk the AST to print the query. This will make handling expressions (such as those in SELECTs) much easier.

Add the AST nodes + formatters we need to get our current SELECT functionality passing. Use the new AST package and formatters for the SELECT builder.

Future PRs will move all other builders over to use the AST, removing the need for the dialect concept.