### PR TITLE
Upgrade GHA for golangci-lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,12 +10,9 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
-          cache: false
+          go-version: stable
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
-        with:
-          version: v1.56.2
+        uses: golangci/golangci-lint-action@v7

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
-version: 2
+version: "2"
 
 run:
   timeout: 3m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,7 @@ linters:
     errcheck:
       check-type-assertions: true
       exclude-functions:
+        - fmt.Fprint
         - fmt.Fprintf
 
     gocritic:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,42 +2,42 @@ run:
   timeout: 3m
 
 linters:
-  disable-all: true
+  default: none
   enable:
     - errcheck
-    - gosimple
     - govet
     - ineffassign
     - staticcheck
-    - typecheck
     - unused
     - goconst
     - gocritic
-    - goimports
     - nilnil
     - nolintlint
     - rowserrcheck
     - unconvert
     - unparam
+  settings:
+    errcheck:
+      check-type-assertions: true
 
-linters-settings:
-  errcheck:
-    check-type-assertions: true
+    gocritic:
+      settings:
+        captLocal:
+          paramsOnly: false
+        underef:
+          skipRecvDeref: false
 
-  gocritic:
-    settings:
-      captLocal:
-        paramsOnly: false
-      underef:
-        skipRecvDeref: false
+    govet:
+      enable-all: true
+      disable:
+        - fieldalignment
+      settings:
+        shadow:
+          strict: true
 
-  govet:
-    enable-all: true
-    disable:
-      - fieldalignment
-    settings:
-      shadow:
-        strict: true
+    nolintlint:
+      require-specific: true
 
-  nolintlint:
-    require-specific: true
+formatters:
+  enable:
+    - goimports

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,6 +42,9 @@ linters:
     nolintlint:
       require-specific: true
 
+    staticcheck:
+      checks: ["all", "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022", "-QF1008"]
+
 formatters:
   enable:
     - goimports

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,8 @@ linters:
   settings:
     errcheck:
       check-type-assertions: true
+      exclude-functions:
+        - fmt.Fprintf
 
     gocritic:
       settings:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,5 @@
+version: 2
+
 run:
   timeout: 3m
 


### PR DESCRIPTION
Upgrade the golangci-lint action, the versionf of golangci-lint itself, and everything else in the GHA.