### PR TITLE
Add support for IS NULL and IS NOT NULL filters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,9 +36,6 @@ linters:
       enable-all: true
       disable:
         - fieldalignment
-      settings:
-        shadow:
-          strict: true
 
     nolintlint:
       require-specific: true

--- a/sqlbuilder/filter/filter.go
+++ b/sqlbuilder/filter/filter.go
@@ -130,3 +130,20 @@ func (f InFilter[T]) IntoExpr() ast.Expr {
 	}
 	return ast.NewBinaryExpr(ast.NewIdentifier(f.Column), ast.BinaryIn, ast.NewTupleLiteral(exprs...))
 }
+
+type NullFilter struct {
+	column string
+	op     ast.UnaryExprOperator
+}
+
+func IsNull(column string) NullFilter {
+	return NullFilter{column: column, op: ast.UnaryIsNull}
+}
+
+func IsNotNull(column string) NullFilter {
+	return NullFilter{column: column, op: ast.UnaryIsNotNull}
+}
+
+func (f NullFilter) IntoExpr() ast.Expr {
+	return ast.NewUnaryExpr(ast.NewIdentifier(f.column), f.op)
+}

--- a/sqlbuilder/formatter/sqlite.go
+++ b/sqlbuilder/formatter/sqlite.go
@@ -52,6 +52,8 @@ func (s Sqlite) FormatNode(w io.Writer, n ast.Node) {
 		s.formatLock(w, tn)
 	case *ast.Where:
 		s.formatWhere(w, tn)
+	case *ast.UnaryExpr:
+		s.formatUnaryExpr(w, tn)
 	case *ast.BinaryExpr:
 		s.formatBinaryExpr(w, tn)
 	case *ast.PlaceholderLiteral:
@@ -339,6 +341,27 @@ func (s Sqlite) formatAlias(w io.Writer, a *ast.Alias) {
 
 func (s Sqlite) formatTableAlias(w io.Writer, a *ast.TableAlias) {
 	s.FormatNode(w, a.Alias)
+}
+
+func (s Sqlite) formatUnaryExpr(w io.Writer, un *ast.UnaryExpr) {
+	// For postfix operators, we format the operand before the operator.
+	if un.Op.IsPost() {
+		s.FormatNode(w, un.Operand)
+	}
+
+	switch un.Op {
+	case ast.UnaryIsNotNull:
+		fmt.Fprint(w, " IS NOT NULL")
+	case ast.UnaryIsNull:
+		fmt.Fprint(w, " IS NULL")
+	default:
+		panic(fmt.Sprintf("unexpected ast.UnaryExprOperator: %#v", un.Op))
+	}
+
+	// For prefix operators, we format the operand after the operator.
+	if !un.Op.IsPost() {
+		s.FormatNode(w, un.Operand)
+	}
 }
 
 func (s Sqlite) formatBinaryExpr(w io.Writer, bin *ast.BinaryExpr) {

--- a/sqlbuilder/internal/ast/expr.go
+++ b/sqlbuilder/internal/ast/expr.go
@@ -27,6 +27,47 @@ type Expr interface {
 	expr()
 }
 
+type UnaryExprOperator int
+
+const (
+	UnaryIsNull    UnaryExprOperator = iota
+	UnaryIsNotNull UnaryExprOperator = iota
+)
+
+func (op UnaryExprOperator) IsPost() bool {
+	switch op {
+	case UnaryIsNotNull:
+		return true
+	case UnaryIsNull:
+		return true
+	default:
+		return false
+	}
+}
+
+type UnaryExpr struct {
+	Expr
+	Op      UnaryExprOperator
+	Operand Expr
+}
+
+func NewUnaryExpr(operand Expr, op UnaryExprOperator) *UnaryExpr {
+	return &UnaryExpr{
+		Op:      op,
+		Operand: operand,
+	}
+}
+
+func (u *UnaryExpr) IntoExpr() Expr {
+	return u
+}
+
+func (u *UnaryExpr) AcceptVisitor(fn func(Node) bool) {
+	if fn(u) {
+		u.Operand.AcceptVisitor(fn)
+	}
+}
+
 type BinaryExprOperator int
 
 const (


### PR DESCRIPTION
This required adding the concept of a unary operator. IS NOT? NULL are then implemented as unary postfix operators.